### PR TITLE
chore(workflow): update the action packages to the latest version

### DIFF
--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
           cache: 'npm'
           cache-dependency-path: package-lock.json
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
           cache: 'pip'


### PR DESCRIPTION
## Problem Description
We encounted the following issue in the github action.
<img width="701" alt="截屏2025-04-20 23 07 28" src="https://github.com/user-attachments/assets/8113ec4f-ef17-4324-b1c8-6fa20b0e75c0" />

Following the instruction https://github.com/actions/setup-node/issues/1275, the issue should be resolved by upgrading all the packages to the latest one inthe workflow file.

## How to test
Here is the test results of the updated workflow file.
https://github.com/Kwenta/kwenta-data/actions/runs/14562932980
